### PR TITLE
Improve README and update MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# pc_proof
+
+A minimal toolkit for propositional logic.
+
+## Features
+- formula parser
+- sequent calculus prover
+- tableau solver with countermodels
+- upcoming SVG proof diagrams via Graphviz
+
+## Install
+Requires Python 3.10+ and Graphviz.
+```bash
+pip install -e .
+```
+
+## Example
+```python
+from sequent import prove
+from tableau import solve
+
+prove("p or not p")
+taut, model = solve("p and not p", tautology=True)
+print(taut, model)
+```
+
+## License
+MIT. See [LICENSE](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "pc_proof"
 version = "0.1.0"
+license = {text = "MIT"}
+readme = "README.md"
 
 dependencies = [
   "lark>=1.2",      # or just "lark"


### PR DESCRIPTION
## Summary
- shorten README and mention Graphviz for planned SVG proof diagrams
- update license year to 2025

## Testing
- `PYTHONPATH=. .venv/bin/pytest -q`