### PR TITLE
Implement proof visualization via Graphviz

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A minimal toolkit for propositional logic.
 - formula parser
 - sequent calculus prover
 - tableau solver with countermodels
-- upcoming SVG proof diagrams via Graphviz
+- SVG proof diagrams via Graphviz using `prove_svg`
 
 ## Install
 Requires Python 3.10+ and Graphviz.
@@ -18,10 +18,12 @@ pip install -e .
 ```python
 from sequent import prove
 from tableau import solve
+from viz import prove_svg
 
 prove("p or not p")
 taut, model = solve("p and not p", tautology=True)
 print(taut, model)
+prove_svg("p or not p", "proof")
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,4 @@ dev = [
 ]
 [tool.setuptools]
 package-dir = {"" = "src"}
-py-modules = ["parser", "sequent", "tableau"]
+py-modules = ["parser", "sequent", "tableau", "viz"]

--- a/src/viz.py
+++ b/src/viz.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+from itertools import count
+from typing import List, Tuple
+
+from graphviz import Digraph
+
+from parser import parse, Var, Const, Not, Bin, Expr
+from sequent import is_literal
+
+
+_counter = count()
+
+
+def _fmt(expr: Expr) -> str:
+    if isinstance(expr, Var):
+        return expr.name
+    if isinstance(expr, Const):
+        return "⊤" if expr.value else "⊥"
+    if isinstance(expr, Not):
+        return f"¬{_fmt(expr.expr)}"
+    if isinstance(expr, Bin):
+        op = {"AND": "∧", "OR": "∨", "IMPL": "→"}[expr.op]
+        return f"({_fmt(expr.left)} {op} {_fmt(expr.right)})"
+    raise ValueError(f"unknown expr: {expr}")
+
+
+def _fmt_list(lst: List[Expr]) -> str:
+    if not lst:
+        return ""
+    return ", ".join(_fmt(e) for e in lst)
+
+
+def _prove_graph(left: List[Expr], right: List[Expr], g: Digraph) -> Tuple[bool, str]:
+    node_id = str(next(_counter))
+    label = f"{_fmt_list(left)} |- {_fmt_list(right)}"
+    g.node(node_id, label=label)
+
+    # simplify constants
+    if any(isinstance(e, Const) and e.value is False for e in left):
+        g.node(node_id, label=label, color="green")
+        return True, node_id
+    if any(isinstance(e, Const) and e.value is True for e in right):
+        g.node(node_id, label=label, color="green")
+        return True, node_id
+
+    left = [e for e in left if not (isinstance(e, Const) and e.value is True)]
+    right = [e for e in right if not (isinstance(e, Const) and e.value is False)]
+
+    # identity
+    for e in left:
+        if e in right:
+            g.node(node_id, label=label, color="green")
+            return True, node_id
+
+    # atomic failure
+    if all(is_literal(e) for e in left + right):
+        g.node(node_id, label=label, color="red")
+        return False, node_id
+
+    # expand left formulas
+    for i, e in enumerate(left):
+        if is_literal(e):
+            continue
+        rest = left[:i] + left[i + 1 :]
+        if isinstance(e, Not):
+            res, child = _prove_graph(rest, right + [e.expr], g)
+            g.edge(node_id, child)
+            g.node(node_id, label=label, color="green" if res else "red")
+            return res, node_id
+        if isinstance(e, Bin):
+            if e.op == "AND":
+                res, child = _prove_graph(rest + [e.left, e.right], right, g)
+                g.edge(node_id, child)
+                g.node(node_id, label=label, color="green" if res else "red")
+                return res, node_id
+            if e.op == "OR":
+                r1, c1 = _prove_graph(rest + [e.left], right, g)
+                r2, c2 = _prove_graph(rest + [e.right], right, g)
+                g.edge(node_id, c1)
+                g.edge(node_id, c2)
+                res = r1 and r2
+                g.node(node_id, label=label, color="green" if res else "red")
+                return res, node_id
+            if e.op == "IMPL":
+                r1, c1 = _prove_graph(rest, right + [e.left], g)
+                r2, c2 = _prove_graph(rest + [e.right], right, g)
+                g.edge(node_id, c1)
+                g.edge(node_id, c2)
+                res = r1 and r2
+                g.node(node_id, label=label, color="green" if res else "red")
+                return res, node_id
+
+    # expand right formulas
+    for i, e in enumerate(right):
+        if is_literal(e):
+            continue
+        rest = right[:i] + right[i + 1 :]
+        if isinstance(e, Not):
+            res, child = _prove_graph(left + [e.expr], rest, g)
+            g.edge(node_id, child)
+            g.node(node_id, label=label, color="green" if res else "red")
+            return res, node_id
+        if isinstance(e, Bin):
+            if e.op == "AND":
+                r1, c1 = _prove_graph(left, rest + [e.left], g)
+                r2, c2 = _prove_graph(left, rest + [e.right], g)
+                g.edge(node_id, c1)
+                g.edge(node_id, c2)
+                res = r1 and r2
+                g.node(node_id, label=label, color="green" if res else "red")
+                return res, node_id
+            if e.op == "OR":
+                res, child = _prove_graph(left, rest + [e.left, e.right], g)
+                g.edge(node_id, child)
+                g.node(node_id, label=label, color="green" if res else "red")
+                return res, node_id
+            if e.op == "IMPL":
+                res, child = _prove_graph(left + [e.left], rest + [e.right], g)
+                g.edge(node_id, child)
+                g.node(node_id, label=label, color="green" if res else "red")
+                return res, node_id
+
+    g.node(node_id, label=label, color="red")
+    return False, node_id
+
+
+def prove_svg(text: str, outfile: str) -> bool:
+    """Prove ``text`` and save the proof tree as SVG to ``outfile``."""
+    ast = parse(text)
+    g = Digraph(format="svg")
+    res, root = _prove_graph([], [ast], g)
+    g.render(outfile, format="svg", cleanup=True)
+    return res
+

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,0 +1,24 @@
+import os
+import shutil
+import pytest
+from viz import prove_svg
+
+pytestmark = pytest.mark.skipif(shutil.which("dot") is None, reason="graphviz not installed")
+
+
+def test_svg_generation(tmp_path):
+    out = tmp_path / "proof"
+    res = prove_svg("p or not p", str(out))
+    assert res is True
+    svg_file = str(out) + ".svg"
+    assert os.path.exists(svg_file)
+    assert os.path.getsize(svg_file) > 0
+
+
+def test_svg_failure(tmp_path):
+    out = tmp_path / "proof2"
+    res = prove_svg("p and not p", str(out))
+    assert res is False
+    svg_file = str(out) + ".svg"
+    assert os.path.exists(svg_file)
+    assert os.path.getsize(svg_file) > 0


### PR DESCRIPTION
## Summary
- add new `viz` module with `prove_svg` to render sequent proofs
- document how to use the new feature
- include `viz` in package metadata
- test SVG generation (skip when graphviz missing)

## Testing
- `uv pip install --system -r pylock.toml`
- `PYTHONPATH=src python -m pytest -q`