### PR TITLE
Fix typos and cleanup

### DIFF
--- a/src/parser.py
+++ b/src/parser.py
@@ -47,9 +47,9 @@ class BuildAST(Transformer):
     def impl_single(self, expr):    return expr
     def paren(self, expr):          return expr
 
-_GRAMMER_PATH = Path(__file__).with_name("logic.lark")
+_GRAMMAR_PATH = Path(__file__).with_name("logic.lark")
 _parser = Lark.open(
-    str(_GRAMMER_PATH),
+    str(_GRAMMAR_PATH),
     parser="lalr",
     transformer=BuildAST(),
     cache=True

--- a/src/tableau.py
+++ b/src/tableau.py
@@ -1,7 +1,7 @@
 from collections import Counter
 from typing import List, Tuple, Union, Optional, cast
 from parser import parse, Var, Const, Not, Bin, Expr
-import sys, pprint
+import sys
 
 def is_literal(node):
     return isinstance(node, (Var, Const)) or (
@@ -14,7 +14,7 @@ def negate(lit):
     return lit.expr if isinstance(lit, Not) else Not(lit)
 
 ExprList = List["Expr"]
-BranchParts = Union[ExprList, List[ExprList]]  #
+BranchParts = Union[ExprList, List[ExprList]]
 
 def decompose(node: Expr) -> Tuple[Optional[str], Optional[BranchParts]]:
     if isinstance(node, Bin):


### PR DESCRIPTION
## Summary
- fix spelling mistake in parser
- drop unused import
- clean up type hint comment

## Testing
- `pytest -q` *(fails: command not found)*